### PR TITLE
Add HEADLESS env support for Playwright

### DIFF
--- a/packages/playwright-worker/README.md
+++ b/packages/playwright-worker/README.md
@@ -24,6 +24,8 @@ CHUKYO_PASSWORD=your_password
 
 # 要件分析用（オプション）
 GOOGLE_AI_API_KEY=your_gemini_api_key
+# Playwright 設定
+HEADLESS=true
 ```
 
 ## 使用方法

--- a/packages/playwright-worker/src/automation.ts
+++ b/packages/playwright-worker/src/automation.ts
@@ -1,5 +1,6 @@
 import { BrowserContext, Page, Locator } from "playwright";
 import { createAuthenticatedContext } from "./login.js";
+import { envBoolean } from "./utils.js";
 
 export interface AutomationOptions {
     stateFile?: string;
@@ -36,7 +37,8 @@ export class ChkyuoAutomationWorker {
      * Initialize the automation worker with authenticated context
      */
     async initialize(): Promise<void> {
-        const { stateFile = "state.json", slowMo = 100, headless = true } = this.options;
+        const envHeadless = envBoolean('HEADLESS', true);
+        const { stateFile = "state.json", slowMo = 100, headless = envHeadless } = this.options;
 
         this.context = await createAuthenticatedContext(stateFile, headless);
         this.page = await this.context.newPage();

--- a/packages/playwright-worker/src/login.ts
+++ b/packages/playwright-worker/src/login.ts
@@ -1,4 +1,5 @@
 import { chromium, Browser, BrowserContext, Page } from "playwright";
+import { envBoolean } from "./utils.js";
 
 export interface LoginOptions {
     username: string;
@@ -19,7 +20,8 @@ export interface LoginResult {
  * Saves session state to state.json on success
  */
 export async function loginToChukyoManabo(options: LoginOptions): Promise<LoginResult> {
-    const { username, password, headless = true, slowMo = 100, timeout = 30000 } = options;
+    const envHeadless = envBoolean('HEADLESS', true);
+    const { username, password, headless = envHeadless, slowMo = 100, timeout = 30000 } = options;
 
     let browser: Browser | null = null;
     let context: BrowserContext | null = null;
@@ -94,7 +96,7 @@ export async function loginToChukyoManabo(options: LoginOptions): Promise<LoginR
 /**
  * Create a new browser context with saved state
  */
-export async function createAuthenticatedContext(stateFile = "state.json", headless = true): Promise<BrowserContext> {
+export async function createAuthenticatedContext(stateFile = "state.json", headless = envBoolean('HEADLESS', true)): Promise<BrowserContext> {
     const browser = await chromium.launch({
         headless,
     });

--- a/packages/playwright-worker/src/utils.ts
+++ b/packages/playwright-worker/src/utils.ts
@@ -1,0 +1,5 @@
+export function envBoolean(name: string, defaultValue = false): boolean {
+  const value = process.env[name];
+  if (value === undefined) return defaultValue;
+  return value.toLowerCase() !== 'false' && value !== '0';
+}


### PR DESCRIPTION
## Summary
- allow `HEADLESS` env variable to control Playwright headless mode
- add helper to parse boolean env vars
- document new env var in playwright-worker README

## Testing
- `bun run scripts/test-all.js`

------
https://chatgpt.com/codex/tasks/task_e_68502ad4e9048321a1d3c47a2c578287