### PR TITLE
Add portal worker tests and fix CLI test path

### DIFF
--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1,15 +1,17 @@
 /* eslint-disable functional/no-class */
 
 import { test, expect, describe } from "bun:test";
-import { exec } from "child_process";
-import { promisify } from "util";
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
 
 const execAsync = promisify(exec);
+const cliPath = path.join('packages', 'cli', 'dist', 'index.js');
 
 describe("CLI Integration Tests", () => {
     test("CLI should show help", async () => {
         try {
-            const { stdout } = await execAsync("bun run dist/index.js --help");
+            const { stdout } = await execAsync(`bun run ${cliPath} --help`);
             expect(stdout).toContain("Chukyo University analysis tools");
             expect(stdout).toContain("analyze");
             expect(stdout).toContain("validate");
@@ -28,7 +30,7 @@ describe("CLI Integration Tests", () => {
 
     test("CLI validate command should work", async () => {
         try {
-            const { stdout } = await execAsync("bun run dist/index.js validate");
+            const { stdout } = await execAsync(`bun run ${cliPath} validate`);
             expect(stdout).toContain("Validating environment");
         } catch (error: any) {
             // Command might exit with code 1 due to missing API key, which is expected
@@ -37,14 +39,14 @@ describe("CLI Integration Tests", () => {
     });
 
     test("CLI config command should show configuration", async () => {
-        const { stdout } = await execAsync("bun run dist/index.js config");
+        const { stdout } = await execAsync(`bun run ${cliPath} config`);
         expect(stdout).toContain("Configuration");
         expect(stdout).toContain("API Key");
         expect(stdout).toContain("Environment Variables");
     });
 
     test("CLI cache command should show cache info", async () => {
-        const { stdout } = await execAsync("bun run dist/index.js cache --info");
+        const { stdout } = await execAsync(`bun run ${cliPath} cache --info`);
         expect(stdout).toContain("Cache Information");
         expect(stdout).toContain("Size:");
         expect(stdout).toContain("TTL:");
@@ -52,7 +54,7 @@ describe("CLI Integration Tests", () => {
 
     test("CLI analyze command should show proper error without URL", async () => {
         try {
-            await execAsync("bun run dist/index.js analyze");
+            await execAsync(`bun run ${cliPath} analyze`);
         } catch (error: any) {
             expect(error.stdout).toContain("URL is required");
         }
@@ -60,7 +62,7 @@ describe("CLI Integration Tests", () => {
 
     test("CLI should handle invalid subcommands gracefully", async () => {
         try {
-            await execAsync("bun run dist/index.js invalid-command");
+            await execAsync(`bun run ${cliPath} invalid-command`);
         } catch (error: any) {
             expect(error.code).toBe(1);
         }

--- a/packages/playwright-worker/__tests__/portal.test.ts
+++ b/packages/playwright-worker/__tests__/portal.test.ts
@@ -1,0 +1,40 @@
+import { test, expect, describe } from 'bun:test';
+import { ChkyuoPortalWorker, createPortalWorker } from '../src/portal.js';
+import { ChkyuoAutomationWorker } from '../src/automation.js';
+
+// Simple stub result for navigateTo
+const successResult = { success: true, message: 'ok' };
+
+describe('Portal Worker goToPortalTop', () => {
+  test('should call navigateTo with portal URL', async () => {
+    const worker = new ChkyuoPortalWorker();
+    let calledUrl: string | null = null;
+    // @ts-ignore override navigateTo for testing
+    worker.navigateTo = async (url: string) => {
+      calledUrl = url;
+      return successResult as any;
+    };
+
+    const result = await worker.goToPortalTop();
+    expect(calledUrl).toBe('https://manabo.cnc.chukyo-u.ac.jp');
+    expect(result).toEqual(successResult);
+  });
+});
+
+describe('createPortalWorker', () => {
+  test('should initialize and return portal worker instance', async () => {
+    let initCalled = false;
+    const originalInit = ChkyuoPortalWorker.prototype.initialize;
+    // @ts-ignore override initialize to avoid real browser
+    ChkyuoPortalWorker.prototype.initialize = async function () {
+      initCalled = true;
+    };
+
+    const worker = await createPortalWorker();
+    expect(initCalled).toBe(true);
+    expect(worker).toBeInstanceOf(ChkyuoPortalWorker);
+    expect(worker).toBeInstanceOf(ChkyuoAutomationWorker);
+
+    ChkyuoPortalWorker.prototype.initialize = originalInit;
+  });
+});


### PR DESCRIPTION
## Summary
- fix CLI tests to use absolute path for dist executable
- add new portal worker tests for goToPortalTop and createPortalWorker

## Testing
- `bun test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68502d37fce4832186e73030338eaf41